### PR TITLE
Enable packages certification in GhostBSD.conf

### DIFF
--- a/usr.sbin/pkg/GhostBSD.conf
+++ b/usr.sbin/pkg/GhostBSD.conf
@@ -9,7 +9,7 @@
 
 GhostBSD: {
   url: "https://pkg.ghostbsd.org/stable/${ABI}/latest",
-  # signature_type: "pubkey",
-  # pubkey: "/usr/share/keys/ssl/certs/ghostbsd.cert",
+  signature_type: "pubkey",
+  pubkey: "/usr/share/keys/ssl/certs/ghostbsd.cert",
   enabled: yes
 }


### PR DESCRIPTION
Related to #162 