### PR TITLE
[nanobsd] - "missing directory in specification" while building disk image

### DIFF
--- a/sys/arm/conf/BEAGLEBONE
+++ b/sys/arm/conf/BEAGLEBONE
@@ -1,0 +1,27 @@
+#
+# BEAGLEBONE -- Custom configuration for the BeagleBone ARM development
+# platforms, check out http://www.beagleboard.org/bone and
+# http://www.beagleboard.org/black. This kernel config file is used for the
+# original BeagleBone and the BeagleBone Black.
+#
+# For more information on this file, please read the config(5) manual page,
+# and/or the handbook section on Kernel Configuration Files:
+#
+#    https://www.FreeBSD.org/doc/en_US.ISO8859-1/books/handbook/kernelconfig-config.html
+#
+# The handbook is also available locally in /usr/share/doc/handbook
+# if you've installed the doc distribution, otherwise always see the
+# FreeBSD World Wide Web server (https://www.FreeBSD.org/) for the
+# latest information.
+#
+# An exhaustive list of options and more detailed explanations of the
+# device lines is also present in the ../../conf/NOTES and NOTES files.
+# If you are in doubt as to the purpose or necessity of a line, check first
+# in NOTES.
+#
+# $FreeBSD$
+
+ident		BEAGLEBONE
+
+include 	"GENERIC"
+

--- a/tools/tools/nanobsd/embedded/beaglebone.cfg
+++ b/tools/tools/nanobsd/embedded/beaglebone.cfg
@@ -32,5 +32,6 @@ NANO_DRIVE=mmcsd0
 NANO_NAME=beaglebone
 NANO_BOOT_PKG=u-boot-beaglebone
 NANO_CPUTYPE=cortex-a8
+NANO_LAYOUT=beaglebone
 
 . common	# Pull in common definitions, keep last

--- a/tools/tools/nanobsd/embedded/common
+++ b/tools/tools/nanobsd/embedded/common
@@ -314,6 +314,12 @@ create_diskimage_mbr ( ) (
 			-p ${s3}:=${NANO_LOG}/_.s3a \
 			-o ${out}
 		;;
+	beaglebone)
+		mkimg -a 1 ${skiparg} ${fmtarg} ${bootmbr} -s mbr -p ${s1}:=${NANO_LOG}/_.s1 \
+			-p ${s2}:=${NANO_LOG}/_.s2 \
+			-p ${s3}:=${NANO_LOG}/_.s3 \
+			-o ${out}
+		;;
 	esac
 	rm -f ${out}.xz
 	xz -9 --keep ${out}
@@ -413,6 +419,11 @@ fix_pkg ( ) (
 	echo "./pkg/cache type=dir uname=root gname=wheel mode=0755"
 	echo "./pkg/db type=dir uname=root gname=wheel mode=0755"
 	echo "./pkg/tmp type=dir uname=root gname=wheel mode=0755"
+        echo "./etc/ssl type=dir uname=root gname=wheel mode=0755"
+        echo "./etc/ssl/blacklisted type=dir uname=root gname=wheel mode=0755"
+        echo "./etc/ssl/certs type=dir uname=root gname=wheel mode=0755"
+        echo "./usr/share/keys/ssl type=dir uname=root gname=wheel mode=0755"
+        echo "./usr/share/keys/ssl/certs type=dir uname=root gname=wheel mode=0755"
 	) >> ${NANO_METALOG}
 )
 customize_cmd fix_pkg
@@ -593,7 +604,7 @@ eval std_${NANO_ARCH}
 : ${NANO_MAKEFS_UFS:=makefs -t ffs -B ${NANO_ENDIAN}}
 : ${NANO_DISK_SCHEME:=mbr}  	# No others really supported ATM (well, gpt)
 case ${NANO_LAYOUT} in
-std-embedded)
+std-embedded|beaglebone)
 	NANO_SLICE_FAT=s1
 	NANO_SLICE_CFG=s2
 	NANO_SLICE_ROOT=s3


### PR DESCRIPTION
Hello,
Building nanobsd on 13.1 failed on the image preparation stage with the "missing directory in specification" error. 
I found an opened ticket in FreeBSD bug tracker which described the issue I experienced https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255639

As for me after I added lines 422-426 in tools/tools/nanobsd/embedded/common the build succeeded. This pull request also includes a couple of small changes: 1. adding BEAGLEBONE kernel config which is currently imply inclusion of GENERIC; 2. adding separate disk layout clause where I needed to set active partition differently. 

Thanks
Max