### PR TITLE
motd.template: updates and corrections

### DIFF
--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -2,7 +2,7 @@
 Welcome to GhostBSD!
 
 Release Notes, Errata:  https://www.GhostBSD.org/releases/
-Security Advisories:    https://www.FreeBSD.org/security/
+Security Advisories:    https://www.freebsd.org/security/advisories/
 GhostBSD Docs:          https://wiki.GhostBSD.org/
 GhostBSD FAQ:           https://ghostbsd-documentation-portal.readthedocs.io/en/latest/user/FAQ.html
 GhostBSD Forums:        https://forums.GhostBSD.org/

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -7,5 +7,5 @@ GhostBSD Forums:        https://forums.ghostbsd.org/
 GhostBSD Development:   https://github.com/orgs/ghostbsd/projects/4
 Security Advisories:    https://www.freebsd.org/security/advisories/
 
-Show the version of GhostBSD installed:  ghostbsd-version
+Show information about GhostBSD: ghostbsd-version -fkov
 Please include that output and any error messages when posting questions.

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -1,11 +1,11 @@
 
 Welcome to GhostBSD!
 
-Release Notes, Errata:  https://www.GhostBSD.org/releases/
 Security Advisories:    https://www.freebsd.org/security/advisories/
 GhostBSD Documentation: https://ghostbsd-documentation-portal.readthedocs.io/
 GhostBSD FAQ:           https://ghostbsd-documentation-portal.readthedocs.io/en/latest/user/FAQ.html
 GhostBSD Forums:        https://forums.ghostbsd.org/
+GhostBSD development:   https://github.com/orgs/ghostbsd/projects/4
 
 Show the version of GhostBSD installed:  ghostbsd-version
 Please include that output and any error messages when posting questions.

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -2,10 +2,10 @@
 Welcome to GhostBSD!
 
 GhostBSD Home:          https://www.ghostbsd.org/
-Security Advisories:    https://www.freebsd.org/security/advisories/
 GhostBSD Documentation: https://ghostbsd-documentation-portal.readthedocs.io/
 GhostBSD Forums:        https://forums.ghostbsd.org/
 GhostBSD development:   https://github.com/orgs/ghostbsd/projects/4
+Security Advisories:    https://www.freebsd.org/security/advisories/
 
 Show the version of GhostBSD installed:  ghostbsd-version
 Please include that output and any error messages when posting questions.

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -5,7 +5,7 @@ Release Notes, Errata:  https://www.GhostBSD.org/releases/
 Security Advisories:    https://www.freebsd.org/security/advisories/
 GhostBSD Docs:          https://wiki.GhostBSD.org/
 GhostBSD FAQ:           https://ghostbsd-documentation-portal.readthedocs.io/en/latest/user/FAQ.html
-GhostBSD Forums:        https://forums.GhostBSD.org/
+GhostBSD Forums:        https://forums.ghostbsd.org/
 
 Show the version of GhostBSD installed:  ghostbsd-version
 Please include that output and any error messages when posting questions.

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -3,7 +3,7 @@ Welcome to GhostBSD!
 
 Release Notes, Errata:  https://www.GhostBSD.org/releases/
 Security Advisories:    https://www.freebsd.org/security/advisories/
-GhostBSD Docs:          https://wiki.GhostBSD.org/
+GhostBSD Documentation: https://ghostbsd-documentation-portal.readthedocs.io/
 GhostBSD FAQ:           https://ghostbsd-documentation-portal.readthedocs.io/en/latest/user/FAQ.html
 GhostBSD Forums:        https://forums.ghostbsd.org/
 

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -4,7 +4,7 @@ Welcome to GhostBSD!
 GhostBSD Home:          https://www.ghostbsd.org/
 GhostBSD Documentation: https://ghostbsd-documentation-portal.readthedocs.io/
 GhostBSD Forums:        https://forums.ghostbsd.org/
-GhostBSD development:   https://github.com/orgs/ghostbsd/projects/4
+GhostBSD Development:   https://github.com/orgs/ghostbsd/projects/4
 Security Advisories:    https://www.freebsd.org/security/advisories/
 
 Show the version of GhostBSD installed:  ghostbsd-version

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -1,6 +1,7 @@
 
 Welcome to GhostBSD!
 
+GhostBSD Home:          https://www.ghostbsd.org/
 Security Advisories:    https://www.freebsd.org/security/advisories/
 GhostBSD Documentation: https://ghostbsd-documentation-portal.readthedocs.io/
 GhostBSD Forums:        https://forums.ghostbsd.org/

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -3,7 +3,6 @@ Welcome to GhostBSD!
 
 Security Advisories:    https://www.freebsd.org/security/advisories/
 GhostBSD Documentation: https://ghostbsd-documentation-portal.readthedocs.io/
-GhostBSD FAQ:           https://ghostbsd-documentation-portal.readthedocs.io/en/latest/user/FAQ.html
 GhostBSD Forums:        https://forums.ghostbsd.org/
 GhostBSD development:   https://github.com/orgs/ghostbsd/projects/4
 

--- a/usr.bin/login/motd.template
+++ b/usr.bin/login/motd.template
@@ -4,7 +4,7 @@ Welcome to GhostBSD!
 Release Notes, Errata:  https://www.GhostBSD.org/releases/
 Security Advisories:    https://www.FreeBSD.org/security/
 GhostBSD Docs:          https://wiki.GhostBSD.org/
-GhostBSD FAQ:           https://wiki.GhostBSD.org/index.php/FAQ
+GhostBSD FAQ:           https://ghostbsd-documentation-portal.readthedocs.io/en/latest/user/FAQ.html
 GhostBSD Forums:        https://forums.GhostBSD.org/
 
 Show the version of GhostBSD installed:  ghostbsd-version


### PR DESCRIPTION
https://wiki.ghostbsd.org/index.php/FAQ is outdated, and no longer the
preferred page. Remove this line.

Use the new URL for documentation. 'Frequently Asked Questions' is
prominent in the sidebar.

Use the true URL for the list of FreeBSD security advisories.

https://www.GhostBSD.org/releases/ is not the place for release notes
and errata; the page does not exist. Instead, use the development
management page in GitHub.

Add the GhostBSD home page.