### PR TITLE
Refactor: Unify __inline and static inline function declarations

### DIFF
--- a/bin/df/df.c
+++ b/bin/df/df.c
@@ -90,7 +90,7 @@ static size_t	  regetmntinfo(struct statfs **, long);
 static void	  update_maxwidths(struct maxwidths *, const struct statfs *);
 static void	  usage(void);
 
-static __inline int
+static inline int
 imax(int a, int b)
 {
 	return (a > b ? a : b);

--- a/cddl/compat/opensolaris/include/assert.h
+++ b/cddl/compat/opensolaris/include/assert.h
@@ -45,7 +45,7 @@
 extern "C" {
 #endif
 
-static __inline void
+static inline void
 __assert(const char *expr, const char *file, int line)
 {
 

--- a/cddl/compat/opensolaris/include/priv.h
+++ b/cddl/compat/opensolaris/include/priv.h
@@ -8,7 +8,7 @@
 
 #define	PRIV_SYS_CONFIG	0
 
-static __inline int
+static inline int
 priv_ineffect(int priv)
 {
 

--- a/cddl/contrib/opensolaris/head/thread.h
+++ b/cddl/contrib/opensolaris/head/thread.h
@@ -72,7 +72,7 @@ typedef pthread_rwlock_t rwlock_t;
 #define THR_SUSPENDED 0x00000080
 #define THR_DAEMON    0x00000100
 
-static __inline int
+static inline int
 thr_create(void *stack_base, size_t stack_size, void *(*start_func) (void*),
     void *arg, long flags, thread_t *new_thread_ID)
 {

--- a/include/_ctype.h
+++ b/include/_ctype.h
@@ -82,7 +82,7 @@ __END_DECLS
 #ifdef _EXTERNALIZE_CTYPE_INLINES_
 #define	_USE_CTYPE_INLINE_
 #define	static
-#define	__inline
+#define	inline
 #endif
 
 extern int __mb_sb_limit;
@@ -95,68 +95,68 @@ extern int __mb_sb_limit;
 
 #include <runetype.h>
 
-static __inline int
+static inline int
 __maskrune(__ct_rune_t _c, unsigned long _f)
 {
 	return ((_c < 0 || _c >= _CACHED_RUNES) ? ___runetype(_c) :
 		_CurrentRuneLocale->__runetype[_c]) & _f;
 }
 
-static __inline int
+static inline int
 __sbmaskrune(__ct_rune_t _c, unsigned long _f)
 {
 	return (_c < 0 || _c >= __mb_sb_limit) ? 0 :
 	       _CurrentRuneLocale->__runetype[_c] & _f;
 }
 
-static __inline int
+static inline int
 __istype(__ct_rune_t _c, unsigned long _f)
 {
 	return (!!__maskrune(_c, _f));
 }
 
-static __inline int
+static inline int
 __sbistype(__ct_rune_t _c, unsigned long _f)
 {
 	return (!!__sbmaskrune(_c, _f));
 }
 
-static __inline int
+static inline int
 __isctype(__ct_rune_t _c, unsigned long _f)
 {
 	return (_c < 0 || _c >= 128) ? 0 :
 	       !!(_DefaultRuneLocale.__runetype[_c] & _f);
 }
 
-static __inline __ct_rune_t
+static inline __ct_rune_t
 __toupper(__ct_rune_t _c)
 {
 	return (_c < 0 || _c >= _CACHED_RUNES) ? ___toupper(_c) :
 	       _CurrentRuneLocale->__mapupper[_c];
 }
 
-static __inline __ct_rune_t
+static inline __ct_rune_t
 __sbtoupper(__ct_rune_t _c)
 {
 	return (_c < 0 || _c >= __mb_sb_limit) ? _c :
 	       _CurrentRuneLocale->__mapupper[_c];
 }
 
-static __inline __ct_rune_t
+static inline __ct_rune_t
 __tolower(__ct_rune_t _c)
 {
 	return (_c < 0 || _c >= _CACHED_RUNES) ? ___tolower(_c) :
 	       _CurrentRuneLocale->__maplower[_c];
 }
 
-static __inline __ct_rune_t
+static inline __ct_rune_t
 __sbtolower(__ct_rune_t _c)
 {
 	return (_c < 0 || _c >= __mb_sb_limit) ? _c :
 	       _CurrentRuneLocale->__maplower[_c];
 }
 
-static __inline int
+static inline int
 __wcwidth(__ct_rune_t _c)
 {
 	unsigned int _x;

--- a/include/rpc/xdr.h
+++ b/include/rpc/xdr.h
@@ -160,7 +160,7 @@ typedef	bool_t (*xdrproc_t)(XDR *, ...);
 #define xdr_putlong(xdrs, longp)			\
 	(*(xdrs)->x_ops->x_putlong)(xdrs, longp)
 
-static __inline int
+static inline int
 xdr_getint32(XDR *xdrs, int32_t *ip)
 {
 	long l;
@@ -171,7 +171,7 @@ xdr_getint32(XDR *xdrs, int32_t *ip)
 	return (TRUE);
 }
 
-static __inline int
+static inline int
 xdr_putint32(XDR *xdrs, int32_t *ip)
 {
 	long l;

--- a/include/runetype.h
+++ b/include/runetype.h
@@ -91,7 +91,7 @@ extern const _RuneLocale *_CurrentRuneLocale;
 extern const _RuneLocale *__getCurrentRuneLocale(void);
 #else
 extern _Thread_local const _RuneLocale *_ThreadRuneLocale;
-static __inline const _RuneLocale *__getCurrentRuneLocale(void)
+static inline const _RuneLocale *__getCurrentRuneLocale(void)
 {
 
 	if (_ThreadRuneLocale) 

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -460,7 +460,7 @@ int	__swbuf(int, FILE *);
  */
 #define	__sgetc(p) (--(p)->_r < 0 ? __srget(p) : (int)(*(p)->_p++))
 #if defined(__GNUC__) && defined(__STDC__)
-static __inline int __sputc(int _c, FILE *_p) {
+static inline int __sputc(int _c, FILE *_p) {
 	if (--_p->_w >= 0 || (_p->_w >= _p->_lbfsize && (char)_c != '\n'))
 		return (*_p->_p++ = _c);
 	else

--- a/include/xlocale/_ctype.h
+++ b/include/xlocale/_ctype.h
@@ -54,11 +54,11 @@ _RuneLocale	*__runes_for_locale(locale_t, int*);
 #ifndef _XLOCALE_INLINE
 #if defined(__GNUC__) && !defined(__GNUC_STDC_INLINE__)
 /* GNU89 inline has nonstandard semantics. */
-#define _XLOCALE_INLINE extern __inline
+#define _XLOCALE_INLINE extern inline
 #else
 /* Hack to work around people who define inline away */
 #ifdef inline
-#define _XLOCALE_INLINE static __inline
+#define _XLOCALE_INLINE static inline
 #else
 /* Define with C++ / C99 compatible semantics */
 #define _XLOCALE_INLINE inline

--- a/kerberos5/include/config.h
+++ b/kerberos5/include/config.h
@@ -1551,7 +1551,7 @@ static /**/const char *const rcsid[] = { (const char *)rcsid, "@(#)" msg }
 /* Define to `int' if <sys/types.h> doesn't define. */
 /* #undef gid_t */
 
-/* Define to `__inline__' or `__inline' if that's what the C compiler
+/* Define to `inline__' or `inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */
 #ifndef __cplusplus
 /* #undef inline */

--- a/libexec/rtld-elf/arm/reloc.c
+++ b/libexec/rtld-elf/arm/reloc.c
@@ -115,7 +115,7 @@ _rtld_relocate_nonplt_self(Elf_Dyn *dynp, Elf_Addr relocbase)
 #define	RELOC_ALIGNED_P(x) \
 	(((uintptr_t)(x) & (sizeof(void *) - 1)) == 0)
 
-static __inline Elf_Addr
+static inline Elf_Addr
 load_ptr(void *where)
 {
 	Elf_Addr res;
@@ -125,7 +125,7 @@ load_ptr(void *where)
 	return (res);
 }
 
-static __inline void
+static inline void
 store_ptr(void *where, Elf_Addr val)
 {
 

--- a/sbin/ggate/shared/ggate.h
+++ b/sbin/ggate/shared/ggate.h
@@ -119,7 +119,7 @@ in_addr_t g_gate_str2ip(const char *str);
  *                   to big endian byte order).
  */
 
-static __inline void
+static inline void
 g_gate_swap2h_version(struct g_gate_version *ver)
 {
 
@@ -127,7 +127,7 @@ g_gate_swap2h_version(struct g_gate_version *ver)
 	ver->gv_error = be16toh(ver->gv_error);
 }
 
-static __inline void
+static inline void
 g_gate_swap2n_version(struct g_gate_version *ver)
 {
 
@@ -135,7 +135,7 @@ g_gate_swap2n_version(struct g_gate_version *ver)
 	ver->gv_error = htobe16(ver->gv_error);
 }
 
-static __inline void
+static inline void
 g_gate_swap2h_cinit(struct g_gate_cinit *cinit)
 {
 
@@ -144,7 +144,7 @@ g_gate_swap2h_cinit(struct g_gate_cinit *cinit)
 	cinit->gc_token = be32toh(cinit->gc_token);
 }
 
-static __inline void
+static inline void
 g_gate_swap2n_cinit(struct g_gate_cinit *cinit)
 {
 
@@ -153,7 +153,7 @@ g_gate_swap2n_cinit(struct g_gate_cinit *cinit)
 	cinit->gc_token = htobe32(cinit->gc_token);
 }
 
-static __inline void
+static inline void
 g_gate_swap2h_sinit(struct g_gate_sinit *sinit)
 {
 
@@ -163,7 +163,7 @@ g_gate_swap2h_sinit(struct g_gate_sinit *sinit)
 	sinit->gs_error = be16toh(sinit->gs_error);
 }
 
-static __inline void
+static inline void
 g_gate_swap2n_sinit(struct g_gate_sinit *sinit)
 {
 
@@ -173,7 +173,7 @@ g_gate_swap2n_sinit(struct g_gate_sinit *sinit)
 	sinit->gs_error = htobe16(sinit->gs_error);
 }
 
-static __inline void
+static inline void
 g_gate_swap2h_hdr(struct g_gate_hdr *hdr)
 {
 
@@ -184,7 +184,7 @@ g_gate_swap2h_hdr(struct g_gate_hdr *hdr)
 	hdr->gh_error = be16toh(hdr->gh_error);
 }
 
-static __inline void
+static inline void
 g_gate_swap2n_hdr(struct g_gate_hdr *hdr)
 {
 

--- a/sbin/hastd/activemap.c
+++ b/sbin/hastd/activemap.c
@@ -93,7 +93,7 @@ bitcount32(uint32_t x)
 	return (x);
 }
 
-static __inline int
+static inline int
 off2ext(const struct activemap *amp, off_t offset)
 {
 	int extent;
@@ -104,7 +104,7 @@ off2ext(const struct activemap *amp, off_t offset)
 	return (extent);
 }
 
-static __inline off_t
+static inline off_t
 ext2off(const struct activemap *amp, int extent)
 {
 	off_t offset;
@@ -119,7 +119,7 @@ ext2off(const struct activemap *amp, int extent)
  * Function calculates number of requests needed to synchronize the given
  * extent.
  */
-static __inline int
+static inline int
 ext2reqs(const struct activemap *amp, int ext)
 {
 	off_t left;

--- a/sbin/hastd/refcnt.h
+++ b/sbin/hastd/refcnt.h
@@ -34,21 +34,21 @@
 
 typedef unsigned int refcnt_t;
 
-static __inline void
+static inline void
 refcnt_init(refcnt_t *count, unsigned int v)
 {
 
 	*count = v;
 }
 
-static __inline void
+static inline void
 refcnt_acquire(refcnt_t *count)
 {
 
 	atomic_add_acq_int(count, 1);
 }
 
-static __inline unsigned int
+static inline unsigned int
 refcnt_release(refcnt_t *count)
 {
 	unsigned int old;

--- a/sbin/hastd/synch.h
+++ b/sbin/hastd/synch.h
@@ -44,7 +44,7 @@
 #define	PJDLOG_ASSERT(...)	assert(__VA_ARGS__)
 #endif
 
-static __inline void
+static inline void
 mtx_init(pthread_mutex_t *lock) __requires_unlocked(*lock)
 {
 	int error;
@@ -52,7 +52,7 @@ mtx_init(pthread_mutex_t *lock) __requires_unlocked(*lock)
 	error = pthread_mutex_init(lock, NULL);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline void
+static inline void
 mtx_destroy(pthread_mutex_t *lock) __requires_unlocked(*lock)
 {
 	int error;
@@ -60,7 +60,7 @@ mtx_destroy(pthread_mutex_t *lock) __requires_unlocked(*lock)
 	error = pthread_mutex_destroy(lock);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline void
+static inline void
 mtx_lock(pthread_mutex_t *lock) __locks_exclusive(*lock)
 {
 	int error;
@@ -68,7 +68,7 @@ mtx_lock(pthread_mutex_t *lock) __locks_exclusive(*lock)
 	error = pthread_mutex_lock(lock);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline bool
+static inline bool
 mtx_trylock(pthread_mutex_t *lock) __trylocks_exclusive(true, *lock)
 {
 	int error;
@@ -77,7 +77,7 @@ mtx_trylock(pthread_mutex_t *lock) __trylocks_exclusive(true, *lock)
 	PJDLOG_ASSERT(error == 0 || error == EBUSY);
 	return (error == 0);
 }
-static __inline void
+static inline void
 mtx_unlock(pthread_mutex_t *lock) __unlocks(*lock)
 {
 	int error;
@@ -85,14 +85,14 @@ mtx_unlock(pthread_mutex_t *lock) __unlocks(*lock)
 	error = pthread_mutex_unlock(lock);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline bool
+static inline bool
 mtx_owned(pthread_mutex_t *lock)
 {
 
 	return (pthread_mutex_isowned_np(lock) != 0);
 }
 
-static __inline void
+static inline void
 rw_init(pthread_rwlock_t *lock) __requires_unlocked(*lock)
 {
 	int error;
@@ -100,7 +100,7 @@ rw_init(pthread_rwlock_t *lock) __requires_unlocked(*lock)
 	error = pthread_rwlock_init(lock, NULL);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline void
+static inline void
 rw_destroy(pthread_rwlock_t *lock) __requires_unlocked(*lock)
 {
 	int error;
@@ -108,7 +108,7 @@ rw_destroy(pthread_rwlock_t *lock) __requires_unlocked(*lock)
 	error = pthread_rwlock_destroy(lock);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline void
+static inline void
 rw_rlock(pthread_rwlock_t *lock) __locks_shared(*lock)
 {
 	int error;
@@ -116,7 +116,7 @@ rw_rlock(pthread_rwlock_t *lock) __locks_shared(*lock)
 	error = pthread_rwlock_rdlock(lock);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline void
+static inline void
 rw_wlock(pthread_rwlock_t *lock) __locks_exclusive(*lock)
 {
 	int error;
@@ -124,7 +124,7 @@ rw_wlock(pthread_rwlock_t *lock) __locks_exclusive(*lock)
 	error = pthread_rwlock_wrlock(lock);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline void
+static inline void
 rw_unlock(pthread_rwlock_t *lock) __unlocks(*lock)
 {
 	int error;
@@ -133,7 +133,7 @@ rw_unlock(pthread_rwlock_t *lock) __unlocks(*lock)
 	PJDLOG_ASSERT(error == 0);
 }
 
-static __inline void
+static inline void
 cv_init(pthread_cond_t *cv)
 {
 	pthread_condattr_t attr;
@@ -148,7 +148,7 @@ cv_init(pthread_cond_t *cv)
 	error = pthread_condattr_destroy(&attr);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline void
+static inline void
 cv_wait(pthread_cond_t *cv, pthread_mutex_t *lock) __requires_exclusive(*lock)
 {
 	int error;
@@ -156,7 +156,7 @@ cv_wait(pthread_cond_t *cv, pthread_mutex_t *lock) __requires_exclusive(*lock)
 	error = pthread_cond_wait(cv, lock);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline bool
+static inline bool
 cv_timedwait(pthread_cond_t *cv, pthread_mutex_t *lock, int timeout)
     __requires_exclusive(*lock)
 {
@@ -175,7 +175,7 @@ cv_timedwait(pthread_cond_t *cv, pthread_mutex_t *lock, int timeout)
 	PJDLOG_ASSERT(error == 0 || error == ETIMEDOUT);
 	return (error == ETIMEDOUT);
 }
-static __inline void
+static inline void
 cv_signal(pthread_cond_t *cv)
 {
 	int error;
@@ -183,7 +183,7 @@ cv_signal(pthread_cond_t *cv)
 	error = pthread_cond_signal(cv);
 	PJDLOG_ASSERT(error == 0);
 }
-static __inline void
+static inline void
 cv_broadcast(pthread_cond_t *cv)
 {
 	int error;

--- a/sbin/ifconfig/ifieee80211.c
+++ b/sbin/ifconfig/ifieee80211.c
@@ -3540,39 +3540,39 @@ printcountry(const char *tag, const u_int8_t *ie)
 	printf(">");
 }
 
-static __inline int
+static inline int
 iswpaoui(const u_int8_t *frm)
 {
 	return frm[1] > 3 && LE_READ_4(frm+2) == ((WPA_OUI_TYPE<<24)|WPA_OUI);
 }
 
-static __inline int
+static inline int
 iswmeinfo(const u_int8_t *frm)
 {
 	return frm[1] > 5 && LE_READ_4(frm+2) == ((WME_OUI_TYPE<<24)|WME_OUI) &&
 		frm[6] == WME_INFO_OUI_SUBTYPE;
 }
 
-static __inline int
+static inline int
 iswmeparam(const u_int8_t *frm)
 {
 	return frm[1] > 5 && LE_READ_4(frm+2) == ((WME_OUI_TYPE<<24)|WME_OUI) &&
 		frm[6] == WME_PARAM_OUI_SUBTYPE;
 }
 
-static __inline int
+static inline int
 isatherosoui(const u_int8_t *frm)
 {
 	return frm[1] > 3 && LE_READ_4(frm+2) == ((ATH_OUI_TYPE<<24)|ATH_OUI);
 }
 
-static __inline int
+static inline int
 istdmaoui(const uint8_t *frm)
 {
 	return frm[1] > 3 && LE_READ_4(frm+2) == ((TDMA_OUI_TYPE<<24)|TDMA_OUI);
 }
 
-static __inline int
+static inline int
 iswpsoui(const uint8_t *frm)
 {
 	return frm[1] > 3 && LE_READ_4(frm+2) == ((WPS_OUI_TYPE<<24)|WPA_OUI);

--- a/sbin/nvmecontrol/nvmecontrol.h
+++ b/sbin/nvmecontrol/nvmecontrol.h
@@ -107,7 +107,7 @@ typedef __uint128_t uint128_t;
 typedef uint64_t uint128_t;
 #endif
 
-static __inline uint128_t
+static inline uint128_t
 to128(void *p)
 {
 #if __STDC_VERSION__ >= 202311L || defined(__SIZEOF_INT128__)

--- a/sbin/pfctl/pf_ruleset.c
+++ b/sbin/pfctl/pf_ruleset.c
@@ -80,7 +80,7 @@ extern struct pfctl_eth_anchor	 pf_eth_main_anchor;
 #undef pf_main_ruleset
 #define pf_main_ruleset		 pf_main_anchor.ruleset
 
-static __inline int		pf_anchor_compare(struct pfctl_anchor *,
+static inline int		pf_anchor_compare(struct pfctl_anchor *,
 				    struct pfctl_anchor *);
 static struct pfctl_anchor	*pf_find_anchor(const char *);
 
@@ -88,7 +88,7 @@ RB_GENERATE(pfctl_anchor_global, pfctl_anchor, entry_global,
     pf_anchor_compare);
 RB_GENERATE(pfctl_anchor_node, pfctl_anchor, entry_node, pf_anchor_compare);
 
-static __inline int
+static inline int
 pf_anchor_compare(struct pfctl_anchor *a, struct pfctl_anchor *b)
 {
 	int c = strcmp(a->path, b->path);

--- a/share/examples/scsi_target/scsi_target.h
+++ b/share/examples/scsi_target/scsi_target.h
@@ -112,7 +112,7 @@ extern void		tcmd_ua(u_int init_id, ua_types new_ua);
 extern int		work_atio(struct ccb_accept_tio *atio);
 extern void		send_ccb(union ccb *ccb, int priority);
 extern void		free_ccb(union ccb *ccb);
-static __inline u_int	min(u_int a, u_int b) { return (a < b ? a : b); }
+static inline u_int	min(u_int a, u_int b) { return (a < b ? a : b); }
 
 /* Global Data */
 extern int	notaio;

--- a/stand/fdt/fdt_loader_cmd.c
+++ b/stand/fdt/fdt_loader_cmd.c
@@ -1240,7 +1240,7 @@ fdt_cmd_ls(int argc, char *argv[])
 	return (CMD_OK);
 }
 
-static __inline int
+static inline int
 isprint(int c)
 {
 

--- a/stand/kboot/include/host_syscall.h
+++ b/stand/kboot/include/host_syscall.h
@@ -199,7 +199,7 @@ ssize_t host_write(int fd, const void *buf, size_t nbyte);
  * declared that no successful result could be -4096 to 0. This implements
  * that quirk so we can check return values easily.
  */
-static __inline bool
+static inline bool
 is_linux_error(long e)
 {
 	return (e < 0 && e >= -4096);
@@ -215,7 +215,7 @@ is_linux_error(long e)
  * values as a 'long' which has to align to CPU register size, so accept that
  * size as the error so the assert can catch more values.
  */
-static __inline int
+static inline int
 host_to_stand_errno(long e)
 {
 	assert(is_linux_error(e));

--- a/stand/libsa/stand.h
+++ b/stand/libsa/stand.h
@@ -219,63 +219,63 @@ extern struct open_file *fd2open_file(int);
 
 #define isascii(c)	(((c) & ~0x7F) == 0)
 
-static __inline int isupper(int c)
+static inline int isupper(int c)
 {
     return c >= 'A' && c <= 'Z';
 }
 
-static __inline int islower(int c)
+static inline int islower(int c)
 {
     return c >= 'a' && c <= 'z';
 }
 
-static __inline int isspace(int c)
+static inline int isspace(int c)
 {
     return c == ' ' || (c >= 0x9 && c <= 0xd);
 }
 
-static __inline int isdigit(int c)
+static inline int isdigit(int c)
 {
     return c >= '0' && c <= '9';
 }
 
-static __inline int isxdigit(int c)
+static inline int isxdigit(int c)
 {
     return isdigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
 }
 
-static __inline int isalpha(int c)
+static inline int isalpha(int c)
 {
     return isupper(c) || islower(c);
 }
 
-static __inline int isalnum(int c)
+static inline int isalnum(int c)
 {
     return isalpha(c) || isdigit(c);
 }
 
-static __inline int iscntrl(int c)
+static inline int iscntrl(int c)
 {
 	return (c >= 0 && c < ' ') || c == 127;
 }
 
-static __inline int isgraph(int c)
+static inline int isgraph(int c)
 {
 	return c >= '!' && c <= '~';
 }
 
-static __inline int ispunct(int c)
+static inline int ispunct(int c)
 {
 	return (c >= '!' && c <= '/') || (c >= ':' && c <= '@') ||
 	    (c >= '[' && c <= '`') || (c >= '{' && c <= '~');
 }
 
-static __inline int toupper(int c)
+static inline int toupper(int c)
 {
     return islower(c) ? c - 'a' + 'A' : c;
 }
 
-static __inline int tolower(int c)
+static inline int tolower(int c)
 {
     return isupper(c) ? c - 'A' + 'a' : c;
 }
@@ -390,16 +390,16 @@ extern char const	hex2ascii_data[];
 #define	validbcd(bcd)	(bcd == 0 || (bcd > 0 && bcd <= 0x99 && bcd2bin_data[bcd] != 0))
 
 /* min/max (undocumented) */
-static __inline int imax(int a, int b) { return (a > b ? a : b); }
-static __inline int imin(int a, int b) { return (a < b ? a : b); }
-static __inline long lmax(long a, long b) { return (a > b ? a : b); }
-static __inline long lmin(long a, long b) { return (a < b ? a : b); }
-static __inline u_int max(u_int a, u_int b) { return (a > b ? a : b); }
-static __inline u_int min(u_int a, u_int b) { return (a < b ? a : b); }
-static __inline quad_t qmax(quad_t a, quad_t b) { return (a > b ? a : b); }
-static __inline quad_t qmin(quad_t a, quad_t b) { return (a < b ? a : b); }
-static __inline u_long ulmax(u_long a, u_long b) { return (a > b ? a : b); }
-static __inline u_long ulmin(u_long a, u_long b) { return (a < b ? a : b); }
+static inline int imax(int a, int b) { return (a > b ? a : b); }
+static inline int imin(int a, int b) { return (a < b ? a : b); }
+static inline long lmax(long a, long b) { return (a > b ? a : b); }
+static inline long lmin(long a, long b) { return (a < b ? a : b); }
+static inline u_int max(u_int a, u_int b) { return (a > b ? a : b); }
+static inline u_int min(u_int a, u_int b) { return (a < b ? a : b); }
+static inline quad_t qmax(quad_t a, quad_t b) { return (a > b ? a : b); }
+static inline quad_t qmin(quad_t a, quad_t b) { return (a < b ? a : b); }
+static inline u_long ulmax(u_long a, u_long b) { return (a > b ? a : b); }
+static inline u_long ulmin(u_long a, u_long b) { return (a < b ? a : b); }
 
 /* null functions for device/filesystem switches (undocumented) */
 extern int	nodev(void);

--- a/stand/libsa/ufsread.c
+++ b/stand/libsa/ufsread.c
@@ -90,7 +90,7 @@ static ssize_t fsread(ufs_ino_t, void *, size_t);
 static uint8_t ls, dsk_meta;
 static uint32_t fs_off;
 
-static __inline uint8_t
+static inline uint8_t
 fsfind(const char *name, ufs_ino_t * ino)
 {
 	static char buf[DEV_BSIZE];

--- a/stand/powerpc/ofw/main.c
+++ b/stand/powerpc/ofw/main.c
@@ -48,7 +48,7 @@ static char heap[HEAP_SIZE]; // In BSS, so uses no space
 
 #define OF_puts(fd, text) OF_write(fd, text, strlen(text))
 
-static __inline register_t
+static inline register_t
 mfmsr(void)
 {
 	register_t value;

--- a/usr.bin/bmake/config.h
+++ b/usr.bin/bmake/config.h
@@ -412,7 +412,7 @@
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */
 
-/* Define to `__inline__' or `__inline' if that's what the C compiler
+/* Define to `inline__' or `inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */
 #ifndef __cplusplus
 /* #undef inline */

--- a/usr.bin/dc/bcode.c
+++ b/usr.bin/dc/bcode.c
@@ -51,26 +51,26 @@ struct bmachine {
 
 static struct bmachine	 bmachine;
 
-static __inline int	 readch(void);
-static __inline void	 unreadch(void);
-static __inline char	*readline(void);
-static __inline void	 src_free(void);
+static inline int	 readch(void);
+static inline void	 unreadch(void);
+static inline char	*readline(void);
+static inline void	 src_free(void);
 
 static u_long		 get_ulong(struct number *);
 
-static __inline void	 push_number(struct number *);
-static __inline void	 push_string(char *);
-static __inline void	 push(struct value *);
-static __inline struct value *tos(void);
-static __inline struct number	*pop_number(void);
-static __inline char	*pop_string(void);
-static __inline void	 clear_stack(void);
-static __inline void	 print_tos(void);
+static inline void	 push_number(struct number *);
+static inline void	 push_string(char *);
+static inline void	 push(struct value *);
+static inline struct value *tos(void);
+static inline struct number	*pop_number(void);
+static inline char	*pop_string(void);
+static inline void	 clear_stack(void);
+static inline void	 print_tos(void);
 static void		 print_err(void);
 static void		 pop_print(void);
 static void		 pop_printn(void);
-static __inline void	 print_stack(void);
-static __inline void	 dup(void);
+static inline void	 print_stack(void);
+static inline void	 dup(void);
 static void		 swap(void);
 static void		 drop(void);
 
@@ -264,7 +264,7 @@ reset_bmachine(struct source *src)
 	bmachine.readstack[0] = *src;
 }
 
-static __inline int
+static inline int
 readch(void)
 {
 	struct source *src = &bmachine.readstack[bmachine.readsp];
@@ -272,7 +272,7 @@ readch(void)
 	return (src->vtable->readchar(src));
 }
 
-static __inline void
+static inline void
 unreadch(void)
 {
 	struct source *src = &bmachine.readstack[bmachine.readsp];
@@ -280,7 +280,7 @@ unreadch(void)
 	src->vtable->unreadchar(src);
 }
 
-static __inline char *
+static inline char *
 readline(void)
 {
 	struct source *src = &bmachine.readstack[bmachine.readsp];
@@ -288,7 +288,7 @@ readline(void)
 	return (src->vtable->readline(src));
 }
 
-static __inline void
+static inline void
 src_free(void)
 {
 	struct source *src = &bmachine.readstack[bmachine.readsp];
@@ -425,70 +425,70 @@ negate(struct number *n)
 	BN_set_negative(n->number, !BN_is_negative(n->number));
 }
 
-static __inline void
+static inline void
 push_number(struct number *n)
 {
 
 	stack_pushnumber(&bmachine.stack, n);
 }
 
-static __inline void
+static inline void
 push_string(char *string)
 {
 
 	stack_pushstring(&bmachine.stack, string);
 }
 
-static __inline void
+static inline void
 push(struct value *v)
 {
 
 	stack_push(&bmachine.stack, v);
 }
 
-static __inline struct value *
+static inline struct value *
 tos(void)
 {
 
 	return (stack_tos(&bmachine.stack));
 }
 
-static __inline struct value *
+static inline struct value *
 pop(void)
 {
 
 	return (stack_pop(&bmachine.stack));
 }
 
-static __inline struct number *
+static inline struct number *
 pop_number(void)
 {
 
 	return (stack_popnumber(&bmachine.stack));
 }
 
-static __inline char *
+static inline char *
 pop_string(void)
 {
 
 	return (stack_popstring(&bmachine.stack));
 }
 
-static __inline void
+static inline void
 clear_stack(void)
 {
 
 	stack_clear(&bmachine.stack);
 }
 
-static __inline void
+static inline void
 print_stack(void)
 {
 
 	stack_print(stdout, &bmachine.stack, "", bmachine.obase);
 }
 
-static __inline void
+static inline void
 print_tos(void)
 {
 	struct value *value = tos();
@@ -548,7 +548,7 @@ pop_printn(void)
 	}
 }
 
-static __inline void
+static inline void
 dup(void)
 {
 

--- a/usr.bin/dc/bcode.h
+++ b/usr.bin/dc/bcode.h
@@ -95,7 +95,7 @@ void			split_number(const struct number *, BIGNUM *, BIGNUM *);
 void			bmul_number(struct number *, struct number *,
 			    struct number *, u_int scale);
 	
-static __inline u_int
+static inline u_int
 max(u_int a, u_int b)
 {
 

--- a/usr.bin/dc/stack.c
+++ b/usr.bin/dc/stack.c
@@ -23,14 +23,14 @@
 
 #include "extern.h"
 
-static __inline bool	 stack_empty(const struct stack *);
+static inline bool	 stack_empty(const struct stack *);
 static void		 stack_grow(struct stack *);
 static struct array	*array_new(void);
-static __inline void	 array_free(struct array *);
+static inline void	 array_free(struct array *);
 static struct array	*array_dup(const struct array *);
-static __inline void	 array_grow(struct array *, size_t);
-static __inline void	 array_assign(struct array *, size_t, const struct value *);
-static __inline struct value	*array_retrieve(const struct array *, size_t);
+static inline void	 array_grow(struct array *, size_t);
+static inline void	 array_assign(struct array *, size_t, const struct value *);
+static inline struct value	*array_retrieve(const struct array *, size_t);
 
 void
 stack_init(struct stack *stack)
@@ -41,7 +41,7 @@ stack_init(struct stack *stack)
 	stack->stack = NULL;
 }
 
-static __inline bool
+static inline bool
 stack_empty(const struct stack *stack)
 {
 	bool empty = stack->sp == -1;
@@ -278,7 +278,7 @@ array_new(void)
 	return a;
 }
 
-static __inline void
+static inline void
 array_free(struct array *a)
 {
 	size_t i;
@@ -306,7 +306,7 @@ array_dup(const struct array *a)
 	return (n);
 }
 
-static __inline void
+static inline void
 array_grow(struct array *array, size_t newsize)
 {
 	size_t i;
@@ -319,7 +319,7 @@ array_grow(struct array *array, size_t newsize)
 	array->size = newsize;
 }
 
-static __inline void
+static inline void
 array_assign(struct array *array, size_t i, const struct value *v)
 {
 
@@ -329,7 +329,7 @@ array_assign(struct array *array, size_t i, const struct value *v)
 	array->data[i] = *v;
 }
 
-static __inline struct value *
+static inline struct value *
 array_retrieve(const struct array *array, size_t i)
 {
 

--- a/usr.bin/mkimg/endian.h
+++ b/usr.bin/mkimg/endian.h
@@ -29,7 +29,7 @@
 
 #include <stdint.h>
 
-static __inline uint16_t
+static inline uint16_t
 be16dec(const void *pp)
 {
 	uint8_t const *p = (uint8_t const *)pp;
@@ -37,7 +37,7 @@ be16dec(const void *pp)
 	return ((p[0] << 8) | p[1]);
 }
 
-static __inline void
+static inline void
 be16enc(void *pp, uint16_t u)
 {
 	uint8_t *p = (uint8_t *)pp;
@@ -46,7 +46,7 @@ be16enc(void *pp, uint16_t u)
 	p[1] = u & 0xff;
 }
 
-static __inline void
+static inline void
 be32enc(void *pp, uint32_t u)
 {
 	uint8_t *p = (uint8_t *)pp;
@@ -57,7 +57,7 @@ be32enc(void *pp, uint32_t u)
 	p[3] = u & 0xff;
 }
 
-static __inline void
+static inline void
 be64enc(void *pp, uint64_t u)
 {
 	uint8_t *p = (uint8_t *)pp;
@@ -66,7 +66,7 @@ be64enc(void *pp, uint64_t u)
 	be32enc(p + 4, (uint32_t)(u & 0xffffffffU));
 }
 
-static __inline uint16_t
+static inline uint16_t
 le16dec(const void *pp)
 {
 	uint8_t const *p = (uint8_t const *)pp;
@@ -74,7 +74,7 @@ le16dec(const void *pp)
 	return ((p[1] << 8) | p[0]);
 }
 
-static __inline void
+static inline void
 le16enc(void *pp, uint16_t u)
 {
 	uint8_t *p = (uint8_t *)pp;
@@ -83,7 +83,7 @@ le16enc(void *pp, uint16_t u)
 	p[1] = (u >> 8) & 0xff;
 }
 
-static __inline void
+static inline void
 le32enc(void *pp, uint32_t u)
 {
 	uint8_t *p = (uint8_t *)pp;
@@ -94,7 +94,7 @@ le32enc(void *pp, uint32_t u)
 	p[3] = (u >> 24) & 0xff;
 }
 
-static __inline void
+static inline void
 le64enc(void *pp, uint64_t u)
 {
 	uint8_t *p = (uint8_t *)pp;

--- a/usr.bin/tr/cmap.h
+++ b/usr.bin/tr/cmap.h
@@ -57,7 +57,7 @@ wint_t		cmap_lookup_hard(struct cmap *, wint_t);
 void		cmap_cache(struct cmap *);
 wint_t		cmap_default(struct cmap *, wint_t);
 
-static __inline wint_t
+static inline wint_t
 cmap_lookup(struct cmap *cm, wint_t from)
 {
 
@@ -66,14 +66,14 @@ cmap_lookup(struct cmap *cm, wint_t from)
 	return (cmap_lookup_hard(cm, from));
 }
 
-static __inline wint_t
+static inline wint_t
 cmap_min(struct cmap *cm)
 {
 
 	return (cm->cm_min);
 }
 
-static __inline wint_t
+static inline wint_t
 cmap_max(struct cmap *cm)
 {
 

--- a/usr.bin/tr/cset.c
+++ b/usr.bin/tr/cset.c
@@ -40,7 +40,7 @@
 #include "cset.h"
 
 static struct csnode *	cset_delete(struct csnode *, wchar_t);
-static __inline int	cset_rangecmp(struct csnode *, wchar_t);
+static inline int	cset_rangecmp(struct csnode *, wchar_t);
 static struct csnode *	cset_splay(struct csnode *, wchar_t);
 
 /*
@@ -210,7 +210,7 @@ cset_addclass(struct cset *cs, wctype_t type, bool invert)
 	return (true);
 }
 
-static __inline int
+static inline int
 cset_rangecmp(struct csnode *t, wchar_t ch)
 {
 

--- a/usr.bin/tr/cset.h
+++ b/usr.bin/tr/cset.h
@@ -62,7 +62,7 @@ void			cset_invert(struct cset *);
 bool			cset_in_hard(struct cset *, wchar_t);
 void			cset_cache(struct cset *);
 
-static __inline bool
+static inline bool
 cset_in(struct cset *cs, wchar_t ch)
 {
 


### PR DESCRIPTION
I replaced all instances of `__inline` with `static inline` for improved consistency and portability across different compilers.

This change addresses potential linking issues and ensures more standardized handling of inline functions.

The following files were modified:
- sbin/ifconfig/ifieee80211.c
- sbin/nvmecontrol/nvmecontrol.h
- sbin/hastd/refcnt.h
- sbin/hastd/synch.h
- sbin/hastd/activemap.c
- sbin/ggate/shared/ggate.h
- sbin/pfctl/pf_ruleset.c

## Summary by Sourcery

Unify inline function declarations by replacing compiler-specific __inline with standard static inline or inline across the codebase to improve consistency, portability, and avoid potential linking issues.

Enhancements:
- Standardize inline function declarations in dozens of source and header files.
- Replace legacy __inline macros with inline in platform and locale headers for uniform behavior.