### PR TITLE
Support audio devices with more than 2 channels

### DIFF
--- a/sbin/sysctl/sysctl.conf
+++ b/sbin/sysctl/sysctl.conf
@@ -16,6 +16,9 @@ kern.ipc.shm_allow_removed=1
 # For Desktop use default for server is 80 
 kern.sched.preempt_thresh=224
 
+# Support audio devices with more than 2 channels
+hw.usb.uaudio.default_channels=6
+
 # this is required for MBR 4 alignement
 kern.geom.part.mbr.enforce_chs=0
 


### PR DESCRIPTION
Currently they don't even show up in the sound device selector. With this, they do. Tested with a BOSE Companion 5 (USB) but likely this will also work for USB audio interfaces with more than 2 channels. 

Possibly the number should be increased even further, so that audio interfaces with even more channels would work.

References:

* https://github.com/gershwin-desktop/issues/issues/5
* https://github.com/helloSystem/ISO/blob/906e988e558a09b6d5a02c809ff874068518f1f2/overlays/uzip/furybsd-settings/files/etc/sysctl.conf#L47-L49