### PR TITLE
Create a freebsd-update package and adding it to jail dependency

### DIFF
--- a/release/packages/ucl/freebsd-update-all.ucl
+++ b/release/packages/ucl/freebsd-update-all.ucl
@@ -1,0 +1,18 @@
+/*
+ * FreeBSD Update Package
+ */
+
+comment = "Binary updates for the FreeBSD base system"
+
+desc = <<EOD
+The freebsd-update(8) utility fetches and installs binary security and
+errata updates for the FreeBSD base system.  It can also be used to
+upgrade from one major or minor version of FreeBSD to another.
+
+freebsd-update(8) uses cryptographic signatures to verify the authenticity
+of downloaded updates, and includes support for rollback of failed updates.
+EOD
+
+annotations {
+	set = "minimal,minimal-jail"
+}

--- a/release/packages/ucl/jail-all.ucl
+++ b/release/packages/ucl/jail-all.ucl
@@ -31,6 +31,12 @@ jails, and an optional rc(8) service to start jails during system startup using
 the /etc/jail.conf configuration file.
 EOD
 
+deps {
+	"freebsd-update" {
+		version = "${VERSION}"
+	}
+}
+
 annotations {
 	set = "optional,optional-jail"
 }

--- a/usr.sbin/freebsd-update/Makefile
+++ b/usr.sbin/freebsd-update/Makefile
@@ -1,3 +1,5 @@
+PACKAGE=	freebsd-update
+
 CONFS=	freebsd-update.conf
 SCRIPTS=freebsd-update.sh
 MAN=	freebsd-update.8


### PR DESCRIPTION
- Split freebsd-update into a separate package
- Include in minimal-jail annotation set
- Make jail package depend on freebsd-update

GhostBSD does not use freebsd-update it will be removed from the default.

## Summary by Sourcery

Introduce a standalone freebsd-update package and update the jail-all package to depend on it.

New Features:
- Split freebsd-update into its own package with accompanying UCL descriptor
- Include freebsd-update in the minimal-jail annotation set and require it in the jail-all package

Build:
- Add Makefile support for the freebsd-update package