### PR TITLE
Updated gfx-glogo.lua and fixed ghostbsd-logo.png position

### DIFF
--- a/stand/lua/gfx-glogo.lua
+++ b/stand/lua/gfx-glogo.lua
@@ -29,24 +29,29 @@
 
 return {
 	logo = {
-		graphic = {
-		    "            ,gggggg.   ",
-		    "         ,agg9*   .g)  ",
-		    "       .agg* ._.,gg*   ",
-		    "     ,gga*  (ggg*'     ",
-		    "    ,ga*      ,ga*     ",
-		    "   ,ga'     .ag*       ",
-		    "  ,ga'   .agga'        ",
-		    "  9g' .agg'g*,a        ",
-		    "  'gggg*',gga'         ",
-		    "       .gg*'           ",
-		    "     .gga*             ",
-		    "   .gga*               ",
-		    "  (ga*                 "
+        ascii = {
+            image = {
+                "            ,gggggg.   ",
+                "         ,agg9*   .g)  ",
+                "       .agg* ._.,gg*   ",
+                "     ,gga*  (ggg*'     ",
+                "    ,ga*      ,ga*     ",
+                "   ,ga'     .ag*       ",
+                "  ,ga'   .agga'        ",
+                "  9g' .agg'g*,a        ",
+                "  'gggg*',gga'         ",
+                "       .gg*'           ",
+                "     .gga*             ",
+                "   .gga*               ",
+                "  (ga*                 "
+            },
+            requires_color = false,
+            shift = {x = 5, y = 3},
 		},
-		requires_color = false,
-		shift = {x = 5, y = 3},
-		image = "/boot/images/ghostbsd-logo.png",
-		image_rl = 15
+		fb = {
+			image = "/boot/images/ghostbsd-logo.png",
+			width = 15,
+			shift = {x = 2, y = -2},
+		},
 	}
 }


### PR DESCRIPTION
The gfx-glogo.lua file was outdated. I brought it up to date.

## Summary by Sourcery

Update gfx-glogo.lua to modernize the logo configuration by restructuring the ASCII graphic section, adding a framebuffer logo subsection, and correcting logo positioning.

New Features:
- Add fb section for framebuffer logo rendering with image path and dimensions

Bug Fixes:
- Adjust shift values to correctly position the GhostBSD logo image

Enhancements:
- Restructure logo configuration by replacing graphic field with ascii.image subsection
- Introduce requires_color and shift parameters under ascii subsection

## Summary by Sourcery

Modernize gfx-glogo.lua by restructuring the ASCII logo configuration, introducing a framebuffer logo subsection, and correcting logo positioning.

New Features:
- Add fb section for framebuffer logo with image path and dimensions

Bug Fixes:
- Adjust shift values to correctly position the GhostBSD logo image

Enhancements:
- Restructure logo configuration by replacing graphic field with ascii.image subsection and introducing requires_color and shift parameters under ascii