### PR TITLE
evdev: create sysctl entries before cdev to close userspace race

### DIFF
--- a/sys/dev/evdev/evdev.c
+++ b/sys/dev/evdev/evdev.c
@@ -324,13 +324,19 @@ evdev_register_common(struct evdev_dev *evdev)
 			goto bail_out;
 	}
 
+	/* Create sysctls before cdev so they exist when devd fires the CREATE
+	 * event.  Userspace (e.g. libudev-devd) reads kern.evdev.input.N.*
+	 * immediately on receiving that event; creating the cdev first causes
+	 * a race where sysctlbyname() fails because the entries are not yet
+	 * registered. */
+	evdev_sysctl_create(evdev);
+
 	/* Create char device node */
 	ret = evdev_cdev_create(evdev);
-	if (ret != 0)
+	if (ret != 0) {
+		sysctl_ctx_free(&evdev->ev_sysctl_ctx);
 		goto bail_out;
-
-	/* Create sysctls (for device enumeration without /dev/input access rights) */
-	evdev_sysctl_create(evdev);
+	}
 
 bail_out:
 	if (ret != 0)


### PR DESCRIPTION
evdev_register_common() was creating the character device before registering the kern.evdev.input.N.* sysctl entries. The moment the cdev appears, devd fires a CREATE event for /dev/input/eventN, and userspace libraries (e.g. libudev-devd) immediately call sysctlbyname("kern.evdev.input.N.name") to enumerate device capabilities. With the old ordering, that call could arrive before the sysctl tree was populated, causing it to fail. The result was that the device was not recognised by the input stack, leaving keyboards and other HID devices non-functional after plug-in or resume from suspend.

Fix the race by calling evdev_sysctl_create() before evdev_cdev_create(). On cdev failure, free the already-registered sysctl context with sysctl_ctx_free() to avoid leaking it.

## Summary by Sourcery

Fix evdev device registration ordering to avoid userspace races when probing new input devices.

Bug Fixes:
- Resolve a race where userspace could query evdev sysctl entries before they were registered when a new input device cdev appeared, causing device enumeration to fail.

Enhancements:
- Ensure sysctl context is freed if character device creation fails after sysctl registration to prevent resource leaks.