### PR TITLE
lualoader: Added a menu option for unmuting logs.

### DIFF
--- a/stand/lua/core.lua
+++ b/stand/lua/core.lua
@@ -36,6 +36,7 @@ local default_acpi = false
 local default_safe_mode = false
 local default_single_user = false
 local default_verbose = false
+local default_mute = true
 
 local bootenv_list = "bootenvs"
 
@@ -46,17 +47,17 @@ local function composeLoaderCmd(cmd_name, argstr)
 	return cmd_name
 end
 
-local function recordDefaults()
+function core.recordDefaults()
 	local boot_single = loader.getenv("boot_single") or "no"
 	local boot_verbose = loader.getenv("boot_verbose") or "no"
+	local boot_mute = loader.getenv("boot_mute") or "no"
 
 	default_acpi = core.getACPI()
 	default_single_user = boot_single:lower() ~= "no"
 	default_verbose = boot_verbose:lower() ~= "no"
+	default_mute = boot_mute:lower() ~= "no"
 
-	core.setACPI(default_acpi)
-	core.setSingleUser(default_single_user)
-	core.setVerbose(default_verbose)
+	core.setDefaults()
 end
 
 
@@ -113,11 +114,23 @@ function core.setVerbose(verbose)
 
 	if verbose then
 		loader.setenv("boot_verbose", "YES")
-		loader.setenv("boot_mute", "NO")
 	else
 		loader.unsetenv("boot_verbose")
 	end
 	core.verbose = verbose
+end
+
+function core.setMute(mute)
+	if mute == nil then
+		mute = not core.mute
+	end
+
+	if mute then
+		loader.setenv("boot_mute", "YES")
+	else
+		loader.unsetenv("boot_mute")
+	end
+	core.mute = mute
 end
 
 function core.setSingleUser(single_user)
@@ -405,6 +418,7 @@ function core.setDefaults()
 	core.setSafeMode(default_safe_mode)
 	core.setSingleUser(default_single_user)
 	core.setVerbose(default_verbose)
+	core.setMute(default_mute)
 end
 
 function core.autoboot(argstr)
@@ -598,6 +612,5 @@ if core.loaderTooOld() then
 	print("**********************************************************************")
 end
 
-recordDefaults()
 hook.register("config.reloaded", core.clearCachedKernels)
 return core

--- a/stand/lua/menu.lua
+++ b/stand/lua/menu.lua
@@ -34,6 +34,8 @@ local config = require("config")
 local screen = require("screen")
 local drawer = require("drawer")
 
+core.recordDefaults()
+
 local menu = {}
 
 local drawn_menu
@@ -213,6 +215,17 @@ menu.boot_options = {
 			end,
 			func = core.setVerbose,
 			alias = {"v", "V"},
+		},
+		-- mute logs
+		{
+			entry_type = core.MENU_ENTRY,
+			name = function()
+				return  "Mute " ..
+					OnOff(color.highlight("L") ..
+					"ogs    :", core.mute)
+			end,
+			func = core.setMute,
+			alias = {"l", "L"},
 		},
 	},
 }


### PR DESCRIPTION
Added a menu option for toggling the `boot_menu` kenv variable so that the user can easily toggle `boot_menu` off to see the kernel messages. Useful for debugging, etc.

Also moved the `core.recordDefaults()` out of the end of core.lua and put it on top of menu.lua . When the function ran at the end of core.lua, it did not capture the variables defined in loader configuration files. This is a small bug in base.

This feature came up on discussions and I thought it would be useful to have. The patch is also included in the unionfs ISO I have shared for testing.

## Summary by Sourcery

Add support for toggling kernel boot log muting from the loader menu and ensure default boot options are captured correctly from configuration.

New Features:
- Expose a boot menu option to toggle kernel log muting by controlling the boot_mute environment variable.

Bug Fixes:
- Ensure default boot options are recorded after loader configuration files are processed so their values are correctly captured.

Enhancements:
- Introduce core.setMute and integrate mute state into the shared default boot options mechanism.