### PR TITLE
psm(4): Disabled IMEX side-buttons by default.

### DIFF
--- a/sys/dev/atkbdc/psm.c
+++ b/sys/dev/atkbdc/psm.c
@@ -531,6 +531,7 @@ static int verbose = PSM_DEBUG;
 static int synaptics_support = 1;
 static int trackpoint_support = 1;
 static int elantech_support = 1;
+static int explorer_sidebuttons = 0;
 static int mux_disabled = -1;
 
 /* for backward compatibility */
@@ -2991,6 +2992,9 @@ SYSCTL_INT(_hw_psm, OID_AUTO, trackpoint_support, CTLFLAG_RDTUN,
 SYSCTL_INT(_hw_psm, OID_AUTO, elantech_support, CTLFLAG_RDTUN,
     &elantech_support, 0, "Enable support for Elantech touchpads");
 
+SYSCTL_INT(_hw_psm, OID_AUTO, explorer_sidebuttons, CTLFLAG_RW,
+    &explorer_sidebuttons, 0, "Enable support for Intellimouse Explorer side buttons");
+
 SYSCTL_INT(_hw_psm, OID_AUTO, mux_disabled, CTLFLAG_RDTUN,
     &mux_disabled, 0, "Disable active multiplexing");
 
@@ -4998,6 +5002,10 @@ psmsoftintr(void *arg)
 			z = (pb->ipacket[3] & MOUSE_EXPLORER_ZNEG) ?
 			    (pb->ipacket[3] & 0x0f) - 16 :
 			    (pb->ipacket[3] & 0x0f);
+			if (!explorer_sidebuttons)
+			{
+				break;
+			}
 			ms.button |=
 			    (pb->ipacket[3] & MOUSE_EXPLORER_BUTTON4DOWN) ?
 			    MOUSE_BUTTON4DOWN : 0;


### PR DESCRIPTION
This is a workaround.
At least two hypervisors (QEMU and VBox) are detected to be using this mouse model by default and they send superfluous side button key events when using the scroll wheel.

Added a runtime rw sysctl that disables the side buttons on this specific model to workaround this issue.

This issue was also mentioned by users in discussions.
Links to some of other mentions of this issue I have found:
https://forums.freebsd.org/threads/gnome3-weird-scroll-wheel-behaviour.78532/
https://www.reddit.com/r/freebsd/comments/o8k71l/anyone_else_having_weird_behaviour_with_scrolling/

## Summary by Sourcery

Disable Intellimouse Explorer side buttons by default via a runtime sysctl to avoid spurious button events from this mouse model.

Bug Fixes:
- Work around hypervisors sending spurious Intellimouse Explorer side button events when using the scroll wheel.

Enhancements:
- Add a runtime rw sysctl to allow enabling Intellimouse Explorer side buttons when desired.